### PR TITLE
Fix naming consistency

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -364,7 +364,7 @@ class apache (
       notify  => $apache::manage_service_autorestart,
       source  => $apache::source_dir,
       recurse => true,
-      purge   => $bool_source_dir_purge,
+      purge   => $apache::bool_source_dir_purge,
       replace => $apache::manage_file_replace,
       audit   => $apache::manage_audit,
     }


### PR DESCRIPTION
Change usage of bool_source_dir in order to agree to example42 naming rules.
