### PR TITLE
Add a 'Listen' directive to the vhost template

### DIFF
--- a/templates/virtualhost/vhost.conf.erb
+++ b/templates/virtualhost/vhost.conf.erb
@@ -1,5 +1,9 @@
 # File Managed by Puppet
 
+<% if port != "80" -%>
+Listen <%= port %>
+<% end -%>
+
 <VirtualHost *:<%= port %>>
     ServerAdmin webmaster@<%= name %>
     DocumentRoot <%= real_docroot %>


### PR DESCRIPTION
In class apache::vhost the port parameter is set to 80 as default. 

You can set 'port' as a paramter to whatever you like. But you will not be able to get a response to your request. This happens because apache is not listening on this port.

I add three lines to add this listen directive to the vhost.conf.erb
