### PR TITLE
change require attribute of service from static Package['apache'] to configurable  param with the default value Package['apache']

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,6 +223,7 @@ class apache (
   $package             = params_lookup( 'package' ),
   $service             = params_lookup( 'service' ),
   $service_status      = params_lookup( 'service_status' ),
+  $service_requires	   = params_lookup( 'service_requires' ),
   $process             = params_lookup( 'process' ),
   $process_args        = params_lookup( 'process_args' ),
   $process_user        = params_lookup( 'process_user' ),
@@ -338,7 +339,7 @@ class apache (
     enable     => $apache::manage_service_enable,
     hasstatus  => $apache::service_status,
     pattern    => $apache::process,
-    require    => Package['apache'],
+    require    => $service_requires,
   }
 
   file { 'apache.conf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,6 +123,7 @@ class apache::params {
   $template = ''
   $options = ''
   $service_autorestart = true
+  $service_requires = Package['apache']
   $absent = false
   $disable = false
   $disableboot = false


### PR DESCRIPTION
very small change, but it helps, if you want to use your apache module, but need to be able to define more requirements than only Package['apache'] to let your puppet recipe succeed; e.g. run a crowd-integration recipe (which is not published as a common apache module) before the service will be started/reloaded.
