### PR TITLE
On some distros, conf folder is conf-available/enabled, instead of conf.d

### DIFF
--- a/manifests/dotconf.pp
+++ b/manifests/dotconf.pp
@@ -38,8 +38,9 @@ define apache::dotconf (
   # if conf.d does not exist, but conf-enabled does, create a symlink between the two
   $symlink = "ln -s '${apache::config_dir}/conf-enabled' '${apache::config_dir}/conf.d'"
   exec { $symlink:
-    onlyif => "test ! -d '${apache::config_dir}/conf.d' && test -d '${apache::config_dir}/conf-enabled'",
+    onlyif => "test ! -d ${apache::config_dir}/conf.d -a -d ${apache::config_dir}/conf-enabled",
     path   => '/bin:/usr/bin',
+    require => Package['apache']
   }
 
   file { "Apache_$name.conf":


### PR DESCRIPTION
This commit creates a symlink to conf-enabled, if conf-enabled exists AND conf.d does not.
