### PR TITLE
When adding or removing vhost restart the service for changes to take effect

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -235,7 +235,7 @@ define apache::vhost (
         ensure  => $file_vhost_link_ensure,
         path    => $config_file_enable_path,
         require => Package['apache'],
-        notify  => $apache::manage_service_autorestart
+        notify  => $apache::manage_service_autorestart,
       }
     }
     redhat,centos,scientific,fedora: {


### PR DESCRIPTION
I didn't add the change to the virtualhost.pp due to deprecation and backwards comp.
Checked the other classes etc and all notify the service to restart. 
