### PR TITLE
Added IP address as parameter to vhost class.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -5,6 +5,9 @@
 # == Parameters:
 # [*port*]
 #   The port to configure the host on
+
+# [*ip*]
+#   The ip to configure the host on. Default: * (all IPs)
 #
 # [*docroot*]
 #   The VirtualHost DocumentRoot
@@ -121,6 +124,7 @@ define apache::vhost (
   $docroot_owner                = 'root',
   $docroot_group                = 'root',
   $port                         = '80',
+  $ip_addr                      = '*',
   $ssl                          = false,
   $template                     = 'apache/virtualhost/vhost.conf.erb',
   $source                       = '',

--- a/templates/virtualhost/vhost.conf.erb
+++ b/templates/virtualhost/vhost.conf.erb
@@ -1,6 +1,6 @@
 # File Managed by Puppet
 
-<VirtualHost *:<%= @port %>>
+<VirtualHost <%= @ip_addr %>:<%= @port %>>
     ServerAdmin <%= @server_admin_email ||= 'webmaster@localhost' %>
     DocumentRoot <%= @real_docroot %>
 <% if @server_name_value != false -%>


### PR DESCRIPTION
A VM I was creating couldn't start apache as I had one ssl-only vhost and the vhost template has the catch-all ("_") hard-coded. I've added ip_addr as a parameter so this can be specified if necessary, with the default of "_" to preserve the current behaviour. It's possibly a slightly bigger change than my previous pull requests on the nginx module so I won't be offended if I've not done it right!
