### PR TITLE
Apache 2.4 require vhost parameter

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -91,8 +91,8 @@
 # [*directory_allow_override*]
 #   Set the directory's override configuration
 #
-# [*directory_require_granted*]
-#   Set the Require all granted attribute for Apache 2.4
+# [*directory_require*]
+#   Set the Require attribute for Apache 2.4
 #
 # [*aliases*]
 #   Set one or more Alias directives (e.g '/phpmyadmin /usr/share/phpMyAdmin'
@@ -150,7 +150,7 @@ define apache::vhost (
   $directory                    = '',
   $directory_options            = '',
   $directory_allow_override     = 'None',
-  $directory_require_granted    = false,
+  $directory_require            = '',
   $aliases                      = ''
 ) {
 

--- a/templates/virtualhost/vhost.conf.erb
+++ b/templates/virtualhost/vhost.conf.erb
@@ -39,7 +39,7 @@
     <% if @passenger_rack_base_uri != ''  %>RackBaseURI <%= @passenger_rack_base_uri %><% end %>
 
 <% end -%>
-<% if @directory_options != "" || @directory_allow_override != "None" -%>
+<% if @directory_options != "" || @directory_allow_override != "None" || @directory_require != "" -%>
     <Directory <%= @real_directory %>>
         <% if @directory_options != "" -%>
         Options <%= @directory_options %>
@@ -47,8 +47,8 @@
         <% if @directory_allow_override != "None" -%>
         AllowOverride <%= @directory_allow_override %>
         <% end -%>
-        <% if @directory_require_granted -%>
-        Require all granted
+        <% if @directory_require != "" -%>
+        Require <%= @directory_require -%>
         <% end -%>
     </Directory>
 <% end -%>


### PR DESCRIPTION
Apache 2.4 now uses the require parameter for vhosts so I have added it to the vhost template with a new directory_require attribute.
