### PR TITLE
Fix for typo in vhost.conf.erb

### DIFF
--- a/templates/virtualhost/vhost.conf.erb
+++ b/templates/virtualhost/vhost.conf.erb
@@ -47,7 +47,7 @@
 <% if @directory_allow_override != "None" -%>
         AllowOverride <%= @directory_allow_override %>
 <% end -%>
-<% if @directory_require != "" %>
+<% if @directory_require != "" -%>
         Require <%= @directory_require %>
 <% end -%>
     </Directory>


### PR DESCRIPTION
There was a typo in the vhost file that only caused a problem with the latest apache version. I have fixed the template and now works correctly
