### PR TITLE
Fix deprecated warning

### DIFF
--- a/templates/virtualhost/vhost.conf.erb
+++ b/templates/virtualhost/vhost.conf.erb
@@ -14,8 +14,8 @@
 <% end -%>
 <% end -%>
 <% if @env_variables != "" -%>
-<% if env_variables.is_a? Array -%>
-<% env_variables.each do |envvars| -%>
+<% if @env_variables.is_a? Array -%>
+<% @env_variables.each do |envvars| -%>
     SetEnv <%= envvars %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
```
Warning: Variable access via 'env_variables' is deprecated. Use '@env_variables' instead. template[/etc/puppet/modules/apache/templates/virtualhost/vhost.conf.erb]:17
   (at /etc/puppet/modules/apache/templates/virtualhost/vhost.conf.erb:17:in `result')
```
