### PR TITLE
Removing the symlink when $enable = absent

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -236,8 +236,9 @@ define apache::vhost (
   case $::operatingsystem {
     ubuntu,debian,mint: {
       $file_vhost_link_ensure = $enable ? {
-        true  => $config_file_path,
-        false => absent,
+        true    => $config_file_path,
+        false   => absent,
+        absent  => absent,
       }
       file { "ApacheVHostEnabled_${name}":
         ensure  => $file_vhost_link_ensure,


### PR DESCRIPTION
When $enable = absent in vhost (which is a valid option in the class), puppet complains about not having a matching value in the selector. Whether $enable = false or absent, the symlink should be removed.
