### PR TITLE
Fixes #72 Supports conf-available/conf-enabled on Ubuntu 14

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'example42-apache'
-version '2.1.8'
+version '2.1.9'
 
 author 'Alessandro Franceschi'
 license 'Apache2'

--- a/manifests/dotconf.pp
+++ b/manifests/dotconf.pp
@@ -21,9 +21,12 @@
 # apache::dotconf { "trac": content => template("trac/apache.conf.erb") }
 #
 define apache::dotconf (
-  $source  = '' ,
-  $content = '' ,
-  $ensure  = present ) {
+  $enable   = true,
+  $source   = '' ,
+  $content  = '' ,
+  $priority = '',
+  $ensure   = present,
+) {
 
   $manage_file_source = $source ? {
     ''        => undef,
@@ -35,9 +38,23 @@ define apache::dotconf (
     default   => $content,
   }
 
+  # Config file path
+  if $priority != '' {
+    $dotconf_path = "${apache::dotconf_dir}/${priority}-${name}.conf"
+  } else {
+    $dotconf_path = "${apache::dotconf_dir}/${name}.conf"
+  }
+
+  # Config file enable path
+  if $priority != '' {
+    $dotconf_enable_path = "${apache::config_dir}/conf-enabled/${priority}-${name}.conf"
+  } else {
+    $dotconf_enable_path = "${apache::config_dir}/conf-enabled/${name}.conf"
+  }
+
   file { "Apache_${name}.conf":
     ensure  => $ensure,
-    path    => "${apache::config_dir}/conf.d/${name}.conf",
+    path    => $dotconf_path,
     mode    => $apache::config_file_mode,
     owner   => $apache::config_file_owner,
     group   => $apache::config_file_group,
@@ -48,4 +65,26 @@ define apache::dotconf (
     audit   => $apache::manage_audit,
   }
 
+  # Some OS specific settings:
+  # Ubuntu 14 uses conf-available / conf-enabled folders
+  case $::operatingsystem {
+    /(?i:Ubuntu)/ : {
+      case $::lsbmajdistrelease {
+        /14/ : {
+          $dotconf_link_ensure = $enable ? {
+            true  => $dotconf_path,
+            false => absent,
+          }
+
+          file { "ApacheDotconfEnabled_${name}":
+            ensure  => $dotconf_link_ensure,
+            path    => $dotconf_enable_path,
+            require => Package['apache'],
+          }
+        }
+        default: { }
+      }
+    }
+    default: { }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -277,6 +277,15 @@ class apache (
     default                   => "${apache::config_dir}/conf.d",
   }
 
+  $dotconf_dir = $::operatingsystem ? {
+    /(?i:Ubuntu)/ => $::lsbmajdistrelease ? {
+      /14/    => "${apache::config_dir}/conf-available",
+      default => "${apache::config_dir}/conf.d",
+    },
+    default => "${apache::config_dir}/conf.d",
+  }
+
+
   ### Definition of some variables used in the module
   $manage_package = $apache::bool_absent ? {
     true  => 'absent',


### PR DESCRIPTION
Ok this has been tested on Ubuntu 14.4 and works. I've tried my best for it to keep existing filepaths the same so that people would experience a smooth upgrade, but I'd be happy if someone could give it a try on Ubuntu 12 and/or other OS to confirm.

Is this conf-available/enabled  a Ubuntu thing, or does it come for Debian? It would be trivial to add debian/mint/other support.
