### PR TITLE
Resolving issue #54

### DIFF
--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -40,7 +40,7 @@
 #   htpasswd_file  => '/etc/httpd/users.passwd',
 # }
 #
-# Set the same user in diferent files 
+# Set the same user in different files 
 # apache::htpasswd { 'myuser':
 #   crypt_password => 'password1',
 #   htpasswd_file  => '/etc/httpd/users.passwd'

--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -7,12 +7,16 @@
 # == Parameters
 #
 # [*ensure*]
-#   Define if the add (present) or remove the user (set as $username)
+#   Define if the add (present) or remove the user (set as $name)
 #   Default: 'present',
 #
 # [*htpasswd_file*]
 #   Path of the htpasswd file to manage.
 #   Default: "${apache::params::config_dir}/htpasswd"
+#
+# [*username*]
+#   Define user name when you have same username and you put it diferent files. 
+#   Default: $name
 #
 # [*crypt_password*]
 #   Crypted password (as it appears in htpasswd)
@@ -45,7 +49,7 @@
 # apache::htpasswd { 'myuser2':
 #   crypt_password => 'password2',
 #   username       => 'myuser',
-#   htpasswd_file  => '/etc/httpd/httpd'
+#   htpasswd_file  => '/etc/httpd/httpd.passwd'
 # }
 #
 define apache::htpasswd (

--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -15,7 +15,7 @@
 #   Default: "${apache::params::config_dir}/htpasswd"
 #
 # [*username*]
-#   Define user name when you have same username and you put it diferent files. 
+#   Define username when you want to put the username in different files 
 #   Default: $name
 #
 # [*crypt_password*]

--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -7,7 +7,7 @@
 # == Parameters
 #
 # [*ensure*]
-#   Define if the add (present) or remove the user (set as $name)
+#   Define if the add (present) or remove the user (set as $username)
 #   Default: 'present',
 #
 # [*htpasswd_file*]
@@ -36,9 +36,23 @@
 #   htpasswd_file  => '/etc/httpd/users.passwd',
 # }
 #
+# Set the same user in diferent files 
+# apache::htpasswd { 'myuser':
+#   crypt_password => 'password1',
+#   username       => ''
+#   htpasswd_file  => '/etc/httpd/users.passwd',
+# }
+#
+# apache::htpasswd { 'myuser2':
+#   crypt_password => 'password2',
+#   username       => 'myuser'
+#   htpasswd_file  => '/etc/httpd/httpd',
+# }
+#
 define apache::htpasswd (
   $ensure           = 'present',
   $htpasswd_file    = '',
+  $username         = $name,
   $crypt_password   = false,
   $clear_password   = false ) {
 
@@ -61,28 +75,28 @@ define apache::htpasswd (
       }
 
       if $crypt_password {
-        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -bp \${OPT} ${real_htpasswd_file} ${name} '${crypt_password}'":
-          unless  => "grep -q '${name}:${crypt_password}' ${real_htpasswd_file}",
+        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -bp \${OPT} ${real_htpasswd_file} ${username} '${crypt_password}'":
+          unless  => "grep -q '${username}:${crypt_password}' ${real_htpasswd_file}",
           path    => '/bin:/sbin:/usr/bin:/usr/sbin',
         }
       }
 
       if $clear_password {
-        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -b \$OPT ${real_htpasswd_file} ${name} ${clear_password}":
-          unless  => "egrep '^${name}:' ${real_htpasswd_file} && grep ${name}:\$(mkpasswd -S \$(egrep '^${name}:' ${real_htpasswd_file} |cut -d : -f 2 |cut -c-2) ${clear_password}) ${real_htpasswd_file}",
+        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -b \$OPT ${real_htpasswd_file} ${username} ${clear_password}":
+          unless  => "egrep '^${username}:' ${real_htpasswd_file} && grep ${username}:\$(mkpasswd -S \$(egrep '^${username}:' ${real_htpasswd_file} |cut -d : -f 2 |cut -c-2) ${clear_password}) ${real_htpasswd_file}",
           path    => '/bin:/sbin:/usr/bin:/usr/sbin',
         }
       }
     }
 
     'absent': {
-      exec { "htpasswd -D ${real_htpasswd_file} ${name}":
-        onlyif => "egrep -q '^${name}:' ${real_htpasswd_file}",
-        notify => Exec["delete ${real_htpasswd_file} after remove ${name}"],
+      exec { "htpasswd -D ${real_htpasswd_file} ${username}":
+        onlyif => "egrep -q '^${username}:' ${real_htpasswd_file}",
+        notify => Exec["delete ${real_htpasswd_file} after remove ${username}"],
         path   => '/bin:/sbin:/usr/bin:/usr/sbin',
       }
 
-      exec { "delete ${real_htpasswd_file} after remove ${name}":
+      exec { "delete ${real_htpasswd_file} after remove ${username}":
         command     => "rm -f ${real_htpasswd_file}",
         onlyif      => "wc -l ${real_htpasswd_file} | egrep -q '^0[^0-9]'",
         refreshonly => true,

--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -39,14 +39,13 @@
 # Set the same user in diferent files 
 # apache::htpasswd { 'myuser':
 #   crypt_password => 'password1',
-#   username       => ''
-#   htpasswd_file  => '/etc/httpd/users.passwd',
+#   htpasswd_file  => '/etc/httpd/users.passwd'
 # }
 #
 # apache::htpasswd { 'myuser2':
 #   crypt_password => 'password2',
-#   username       => 'myuser'
-#   htpasswd_file  => '/etc/httpd/httpd',
+#   username       => 'myuser',
+#   htpasswd_file  => '/etc/httpd/httpd'
 # }
 #
 define apache::htpasswd (


### PR DESCRIPTION
As it was described:
"apache::htpasswd uses the name of the resource as the username to be added to the htpasswd file, and does not provide a way to override that username. That causes a problem when you want to have the same username defined in two different htpasswd files on the same node. If I try to create entries for user1 in both /etc/htpasswd1 and /etc/htpasswd2, I'll get a resource conflict.

A simple solution to this would be to add an additional parameter to apache::htpasswd called username that defaults to $name."