### PR TITLE
Add ability to manage ssl.conf file within apache::ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ For detailed info about the logic and usage patterns of Example42 modules read R
 
         include apache::ssl
 
+	class { 'apache::ssl':
+	  ssl_template => 'example42/apache/ssl.conf.erb',
+	}
+
+	class { 'apache::ssl':
+	  ssl_source => [ "puppet:///modules/lab42/apache/ssl.conf-${hostname}" , "puppet:///modules/lab42/apache/ssl.conf" ],
+	}
+
 
 * Manage basic auth users (Here user joe is created with the $crypt_password on the defined htpasswd_file
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,6 +119,8 @@ class apache::params {
 
   $port = '80'
   $ssl_port = '443'
+  $ssl_source = ''
+  $ssl_template = ''
   $protocol = 'tcp'
 
   # General Settings

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -2,9 +2,23 @@
 #
 # Apache resources specific for SSL
 #
-class apache::ssl {
+class apache::ssl (
+  $ssl_port            = params_lookup( 'ssl_port' ),
+  $ssl_source          = params_lookup( 'ssl_source' ),
+  $ssl_template        = params_lookup( 'ssl_template' ),
+  ) inherits apache::params {
 
   include apache
+
+  $manage_ssl_file_source = $apache::ssl::ssl_source ? {
+    '' => undef,
+    default => $apache::ssl::ssl_source,
+  }
+
+  $manage_ssl_file_content = $apache::ssl::ssl_template ? {
+    '' => undef,
+    default => template($apache::ssl::ssl_template),
+  }
 
   case $::operatingsystem {
     ubuntu,debian,mint: {
@@ -22,11 +36,18 @@ class apache::ssl {
         require => Package['apache'],
         notify  => Service['apache'],
       }
-      file { "${apache::config_dir}/ssl.conf":
-        mode   => '0644',
-        owner  => 'root',
-        group  => 'root',
-        notify => Service['apache'],
+      file { 'ssl.conf':
+        ensure => $apache::manage_file,
+        path => "${apache::ssl::dotconf_dir}/ssl.conf",
+        mode => $apache::config_file_mode,
+        owner => $apache::config_file_owner,
+        group => $apache::config_file_group,
+        require => Package['mod_ssl'],
+        notify => $apache::manage_service_autorestart,
+        source => $apache::ssl::manage_ssl_file_source,
+        content => $apache::ssl::manage_ssl_file_content,
+        replace => $apache::manage_file_replace,
+        audit => $apache::manage_audit,
       }
       file {['/var/cache/mod_ssl', '/var/cache/mod_ssl/scache']:
         ensure  => directory,
@@ -41,9 +62,9 @@ class apache::ssl {
 
   ### Port monitoring, if enabled ( monitor => true )
   if $apache::bool_monitor == true {
-    monitor::port { "apache_${apache::protocol}_${apache::ssl_port}":
+    monitor::port { "apache_${apache::protocol}_${apache::ssl::ssl_port}":
       protocol => $apache::protocol,
-      port     => $apache::ssl_port,
+      port     => $apache::ssl::ssl_port,
       target   => $apache::monitor_target,
       tool     => $apache::monitor_tool,
       enable   => $apache::manage_monitor,
@@ -52,11 +73,11 @@ class apache::ssl {
 
   ### Firewall management, if enabled ( firewall => true )
   if $apache::bool_firewall == true {
-    firewall { "apache_${apache::protocol}_${apache::ssl_port}":
+    firewall { "apache_${apache::protocol}_${apache::ssl::ssl_port}":
       source      => $apache::firewall_src,
       destination => $apache::firewall_dst,
       protocol    => $apache::protocol,
-      port        => $apache::ssl_port,
+      port        => $apache::ssl::ssl_port,
       action      => 'allow',
       direction   => 'input',
       tool        => $apache::firewall_tool,


### PR DESCRIPTION
Added $ssl_template and $ssl_source parameters and enabled apache::ssl to accept these and $ssl_port directly.  I tested and verified it works on Oracle Linux and CentOS 6.

One additional note, I localized parameters in apache::ssl so the monitoring/firewalling params are not defined by the parent class.