### PR TITLE
Integrate apache module with Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,36 @@ For detailed info about the logic and usage patterns of Example42 modules read R
           my_class => 'apache::example42',
         }
 
+## USAGE - Hiera Support
+* Manage apache configuration using Hiera
+
+```yaml
+apache_template: 'modules/apache/apache2.conf.erb'
+apache_options:
+  timeout: '300'
+  keepalive: 'On'
+  maxkeepaliverequests: '100'
+  keepalivetimeout: '5'
+```
+
+* Defining Apache resources using Hiera
+
+```yaml
+apache::virtualhost_hash:
+  'mysite.com':
+    documentroot: '/var/www/mysite.com'
+    aliases: 'www.mysite.com'
+apache::htpasswd_hash:
+  'myuser':
+    crypt_password: 'password1'
+    htpasswd_file: '/etc/apache2/users.passwd'
+apache::listen_hash:
+  '8080':
+    namevirtualhost: '*'
+apache::module_hash:
+  'status':
+    ensure: present
+```
 
 ## USAGE - Example42 extensions management 
 * Activate puppi (recommended, but disabled by default)

--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -59,7 +59,7 @@ define apache::htpasswd (
   $crypt_password   = false,
   $clear_password   = false ) {
 
-  require apache
+  include apache
 
   $real_htpasswd_file = $htpasswd_file ? {
     ''      => "${apache::params::config_dir}/htpasswd",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -256,7 +256,14 @@ class apache (
   $port                      = params_lookup( 'port' ),
   $ssl_port                  = params_lookup( 'ssl_port' ),
   $protocol                  = params_lookup( 'protocol' ),
-  $version                   = params_lookup( 'version' )
+  $version                   = params_lookup( 'version' ),
+  ## Hiera lookup
+  $dotconf_hash              = hiera_hash('apache::dotconf_hash', {} ),
+  $htpasswd_hash             = hiera_hash('apache::htpasswd_hash', {} ),
+  $listen_hash               = hiera_hash('apache::listen_hash', {} ),
+  $module_hash               = hiera_hash('apache::module_hash', {} ),
+  $vhost_hash                = hiera_hash('apache::vhost_hash', {} ),
+  $virtualhost_hash          = hiera_hash('apache::virtualhost_hash', {} ),
   ) inherits apache::params {
 
   $bool_source_dir_purge=any2bool($source_dir_purge)
@@ -269,6 +276,32 @@ class apache (
   $bool_firewall=any2bool($firewall)
   $bool_debug=any2bool($debug)
   $bool_audit_only=any2bool($audit_only)
+
+  ## Integration with Hiera
+  if $dotconf_hash != {} {
+    validate_hash($dotconf_hash)
+    create_resources('apache::dotconf', $dotconf_hash)
+  }
+  if $htpasswd_hash != {} {
+    validate_hash($htpasswd_hash)
+    create_resources('apache::htpasswd', $htpasswd_hash)
+  }
+  if $listen_hash != {} {
+    validate_hash($listen_hash)
+    create_resources('apache::listen', $listen_hash)
+  }
+  if $module_hash != {} {
+    validate_hash($module_hash)
+    create_resources('apache::module', $module_hash)
+  }
+  if $vhost_hash != {} {
+    validate_hash($vhost_hash)
+    create_resources('apache::vhost', $vhost_hash)
+  }
+  if $virtualhost_hash != {} {
+    validate_hash($virtualhost_hash)
+    create_resources('apache::virtualhost', $virtualhost_hash)
+  }
 
   ### Calculation of variables that dependes on arguments
   $vdir = $::operatingsystem ? {
@@ -475,5 +508,4 @@ class apache (
       content => inline_template('<%= scope.to_hash.reject { |k,v| k.to_s =~ /(uptime.*|path|timestamp|free|.*password.*|.*psk.*|.*key)/ }.to_yaml %>'),
     }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -258,12 +258,12 @@ class apache (
   $protocol                  = params_lookup( 'protocol' ),
   $version                   = params_lookup( 'version' ),
   ## Hiera lookup
-  $dotconf_hash              = hiera_hash('apache::dotconf_hash', {} ),
-  $htpasswd_hash             = hiera_hash('apache::htpasswd_hash', {} ),
-  $listen_hash               = hiera_hash('apache::listen_hash', {} ),
-  $module_hash               = hiera_hash('apache::module_hash', {} ),
-  $vhost_hash                = hiera_hash('apache::vhost_hash', {} ),
-  $virtualhost_hash          = hiera_hash('apache::virtualhost_hash', {} ),
+  $dotconf_hash              = {},
+  $htpasswd_hash             = {},
+  $listen_hash               = {},
+  $module_hash               = {},
+  $vhost_hash                = {},
+  $virtualhost_hash          = {},
   ) inherits apache::params {
 
   $bool_source_dir_purge=any2bool($source_dir_purge)


### PR DESCRIPTION
htpasswd.pp - change from 'require' to 'include' to solve dependency cycle when used with hiera.