### PR TITLE
fix/cript_and_clean_password

### DIFF
--- a/manifests/htpasswd.pp
+++ b/manifests/htpasswd.pp
@@ -78,14 +78,14 @@ define apache::htpasswd (
       }
 
       if $crypt_password {
-        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -bp \${OPT} ${real_htpasswd_file} ${username} '${crypt_password}'":
+        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -b \${OPT} ${real_htpasswd_file} ${username} '${crypt_password}'":
           unless => "grep -q '${username}:${crypt_password}' ${real_htpasswd_file}",
           path   => '/bin:/sbin:/usr/bin:/usr/sbin',
         }
       }
 
       if $clear_password {
-        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -b \$OPT ${real_htpasswd_file} ${username} ${clear_password}":
+        exec { "test -f ${real_htpasswd_file} || OPT='-c'; htpasswd -bp \$OPT ${real_htpasswd_file} ${username} ${clear_password}":
           unless => "egrep '^${username}:' ${real_htpasswd_file} && grep ${username}:\$(mkpasswd -S \$(egrep '^${username}:' ${real_htpasswd_file} |cut -d : -f 2 |cut -c-2) ${clear_password}) ${real_htpasswd_file}",
           path   => '/bin:/sbin:/usr/bin:/usr/sbin',
         }


### PR DESCRIPTION
man htpasswd
-p    Use plaintext passwords. Though htpasswd will support creation on all platforms, the httpd daemon will only accept plain text passwords on  Windows,  Netware  and TPF.

I think this is switched:  I have to use -p  with plain and without -p with crypt password.