### PR TITLE
Fix apache::listen for debian8

### DIFF
--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -11,32 +11,29 @@
 #   (it creates a NameVirtualHost <%= @namevirtualhost %>:<%= @port %> entry)
 #   Set to false to listen to the port without a NameVirtualHost
 #
+# [*enable*]
+#   Set to false to disable the listen configuration.
+#   Work only on Debian 8 and Ubuntu 14
+#
 # == Examples
+#
 # apache::listen { '8080':}
 #
 define apache::listen (
+  $enable          = true,
   $namevirtualhost = '*',
   $ensure          = 'present',
   $template        = 'apache/listen.conf.erb',
-  $notify_service  = true ) {
+  $notify_service  = true
+) {
 
   include apache
 
-  $manage_service_autorestart = $notify_service ? {
-    true    => 'Service[apache]',
-    false   => undef,
-  }
-
-  file { "Apache_Listen_${name}.conf":
-    ensure  => $ensure,
-    path    => "${apache::config_dir}/conf.d/0000_listen_${name}.conf",
-    mode    => $apache::config_file_mode,
-    owner   => $apache::config_file_owner,
-    group   => $apache::config_file_group,
-    require => Package['apache'],
-    notify  => $manage_service_autorestart,
-    content => template($template),
-    audit   => $apache::manage_audit,
+  apache::dotconf { "listen_${name}":
+    ensure   => $ensure,
+    enable   => $enable,
+    content  => template($template),
+    priority => '0000',
   }
 
 }


### PR DESCRIPTION
Hi,

This PR modify apache::listen to use apache::dotconf instead of simple file resource type. This allow the script to be compatible with Debian 8 (and Ubuntu 14).

Regards