### PR TITLE
Add apache_fact_version fact

### DIFF
--- a/lib/facter/apache_fact_version.rb
+++ b/lib/facter/apache_fact_version.rb
@@ -1,0 +1,15 @@
+Facter.add(:apache_fact_version) do
+  setcode do
+
+    apache2_cmd_result = Facter::Util::Resolution.exec('[ "$( which apache2 2>/dev/null )" != "" ] && apache2 -v | head -n1 |cut -d"/" -f2|awk \'{ print $1 }\'')
+    httpd_cmd_result = Facter::Util::Resolution.exec('[ "$( which httpd 2>/dev/null )" != "" ] && httpd -v | head -n1 |cut -d"/" -f2|awk \'{ print $1 }\'')
+
+    if not apache2_cmd_result.empty?
+      apache2_cmd_result
+    elsif not httpd_cmd_result.empty?
+      httpd_cmd_result
+    else
+      ""
+    end
+  end
+end


### PR DESCRIPTION
Hi,

This PR add the "apache_fact_version" containing the current apache version. This is particulary usefull if you want to test if you are in 2.2 or 2.4 apache version.

Regards