### PR TITLE
changed to concat version 1.x.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Hi.

I tried to use your module and struggled on the problem, that puppetlabs/concat is no longer available in version 2.x. This caused problems resolving modules with librarian-puppet. The quick solution was to change the the required version to ">=1.0.0". 

Even more, it seems, you are not using concat in this module.

Regards
 Andreas 