### PR TITLE
issue #96: Syntax error in conditional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -305,7 +305,7 @@ class apache (
   ### Calculation of variables that dependes on arguments
   $vdir = $::operatingsystem ? {
     /(?i:Ubuntu|Debian|Mint)/ => "${apache::config_dir}/sites-available",
-    SLES                      => "${apache::config_dir}/vhosts.d",
+    'SLES'                    => "${apache::config_dir}/vhosts.d",
     default                   => "${apache::config_dir}/conf.d",
   }
 


### PR DESCRIPTION
## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 


Current code gives me following error (maybe becaue I'm on Puppet 4?):

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Resource type not found: SLES at /etc/puppetlabs/code/environments/master/modules/apache/manifests/init.pp:308:5 on node xxxxx